### PR TITLE
Starting work to allow option to not redirect away from content after limit is reached.

### DIFF
--- a/adminpages/limitpostviews.php
+++ b/adminpages/limitpostviews.php
@@ -73,6 +73,8 @@ function pmprolpv_settings_field_redirect_page() {
 	wp_dropdown_pages( array(
 		'selected' => $page_id,
 		'name' => 'pmprolpv_redirect_page',
+		'show_option_none' => __( '-- Do Not Redirect --', 'pmpro-limit-post-views'),
+		'option_none_value' => 'no-redirect',
 	));
 }
 

--- a/pmpro-limit-post-views.php
+++ b/pmpro-limit-post-views.php
@@ -173,6 +173,8 @@ function pmpro_lpv_redirect() {
 
 	if ( empty( $page_id ) ) {
 		$redirect_url = pmpro_url( 'levels' );
+	} elseif ( $page_id === 'no-redirect' ) {
+		return;
 	} else {
 		$redirect_url = get_the_permalink( $page_id );
 	}


### PR DESCRIPTION
This is a start to allowing the non-member to not be redirected to your assigned page if they hit the post limit. Users have been asking to stay on the page and just show the non-member message, among other ideas like the one in this issue: https://github.com/strangerstudios/pmpro-limit-post-views/issues/18