### PR TITLE
Fix array merge

### DIFF
--- a/pmpro-limit-post-views.php
+++ b/pmpro-limit-post-views.php
@@ -320,7 +320,10 @@ function pmpro_lpv_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . get_admin_url( null, 'admin.php?page=pmpro-limitpostviews' ) . '">' . __( 'Settings', 'pmpro-limit-post-views' ) . '</a>',
 		);
-		array_merge( $new_links, $links );
+
+		if ( is_array( $links ) && is_array( $new_links ) ) {
+			$links = array_merge( $new_links, $links );
+		}
 	}
 	return $links;
 }

--- a/pmpro-limit-post-views.php
+++ b/pmpro-limit-post-views.php
@@ -320,8 +320,9 @@ function pmpro_lpv_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . get_admin_url( null, 'admin.php?page=pmpro-limitpostviews' ) . '">' . __( 'Settings', 'pmpro-limit-post-views' ) . '</a>',
 		);
+		array_merge( $new_links, $links );
 	}
-	return array_merge( $new_links, $links );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'pmpro_lpv_plugin_action_links' );
 


### PR DESCRIPTION
Call array merge where $new_links is a valid array.

### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-limit-post-views/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-post-views/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The following error was reported:

```
An error of type E_ERROR was caused in line 324 of the file `/wp-content/plugins/pmpro-limit-post-views/pmpro-limit-post-views.php. Error message: Uncaught TypeError: array_merge(): Argument #1 must be of type array, null given. 
```

Merging $new_links array inside the conditional where the array is created to ensure a valid array is passed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

