### PR TITLE
Fix Undefined array key 

### DIFF
--- a/includes/restriction.php
+++ b/includes/restriction.php
@@ -65,10 +65,10 @@ function pmprolpv_get_restriction_js() {
 	// LPV post view data is stored in the cookie pmprolpv cookie as a string [post_id],[timestamp];
 	$lpv_data_string = isset( $_COOKIE['pmprolpv'] ) ? $_COOKIE['pmprolpv'] : '';
 	$lpv_data_array  = array();
-	if (!empty($lpv_data_string)) {
-	    foreach (explode(';', $lpv_data_string) as $lpv_data) {
-		$lpv_data_parts = explode(',', $lpv_data);
-		if (count($lpv_data_parts) === 2) {
+	if ( ! empty( $lpv_data_string ) ) {
+	    foreach ( explode( ';', $lpv_data_string ) as $lpv_data ) {
+		$lpv_data_parts = explode( ',', $lpv_data );
+		if ( count( $lpv_data_parts ) === 2 ) {
 		    $lpv_data_array[] = array(
 			'post_id' => (int) $lpv_data_parts[0],
 			'timestamp' => (int) $lpv_data_parts[1],
@@ -85,20 +85,20 @@ function pmprolpv_get_restriction_js() {
 		'month' => 0,
 	);
 
-	$current_time = current_time('timestamp');
+	$current_time = current_time( 'timestamp' );
 
-	foreach ($lpv_data_array as $lpv_data) {
+	foreach ( $lpv_data_array as $lpv_data ) {
 	    $viewed_time = $lpv_data['timestamp'];
-	    if ($viewed_time >= strtotime('-1 hour', $current_time)) {
+	    if ( $viewed_time >= strtotime( '-1 hour', $current_time ) ) {
 	        $lpv_data_period_counts['hour']++;
 	    }
-	    if ($viewed_time >= strtotime('-1 day', $current_time)) {
+	    if ( $viewed_time >= strtotime( '-1 day', $current_time ) ) {
 	        $lpv_data_period_counts['day']++;
 	    }
-	    if ($viewed_time >= strtotime('-1 week', $current_time)) {
+	    if ( $viewed_time >= strtotime( '-1 week', $current_time ) ) {
 	        $lpv_data_period_counts['week']++;
 	    }
-	    if ($viewed_time >= strtotime('-1 month', $current_time)) {
+	    if ( $viewed_time >= strtotime( '-1 month', $current_time ) ) {
 	        $lpv_data_period_counts['month']++;
 	    }
 	}

--- a/includes/restriction.php
+++ b/includes/restriction.php
@@ -65,12 +65,16 @@ function pmprolpv_get_restriction_js() {
 	// LPV post view data is stored in the cookie pmprolpv cookie as a string [post_id],[timestamp];
 	$lpv_data_string = isset( $_COOKIE['pmprolpv'] ) ? $_COOKIE['pmprolpv'] : '';
 	$lpv_data_array  = array();
-	foreach( explode( ';', $lpv_data_string ) as $lpv_data ) {
-		$lpv_data = explode( ',', $lpv_data );
-		$lpv_data_array[] = array(
-			'post_id' => $lpv_data[0],
-			'timestamp' => $lpv_data[1],
-		);
+	if (!empty($lpv_data_string)) {
+	    foreach (explode(';', $lpv_data_string) as $lpv_data) {
+		$lpv_data_parts = explode(',', $lpv_data);
+		if (count($lpv_data_parts) === 2) {
+		    $lpv_data_array[] = array(
+			'post_id' => (int) $lpv_data_parts[0],
+			'timestamp' => (int) $lpv_data_parts[1],
+		    );
+		}
+	    }
 	}
 
 	// Get the number of posts this hour, day, week, and month.
@@ -80,18 +84,23 @@ function pmprolpv_get_restriction_js() {
 		'week' => 0,
 		'month' => 0,
 	);
-	foreach ( $lpv_data_array as $lpv_data ) {
-		// Use a switch to waterfall through the different periods.
-		switch ( true ) {
-			case $lpv_data['timestamp'] >= strtotime( '-1 hour', current_time( 'timestamp' ) ):
-				$lpv_data_period_counts['hour']++;
-			case $lpv_data['timestamp'] >= strtotime( '-1 day', current_time( 'timestamp' ) ):
-				$lpv_data_period_counts['day']++;
-			case $lpv_data['timestamp'] >= strtotime( '-1 week', current_time( 'timestamp' ) ):
-				$lpv_data_period_counts['week']++;
-			case $lpv_data['timestamp'] >= strtotime( '-1 month', current_time( 'timestamp' ) ):
-				$lpv_data_period_counts['month']++;
-		}
+
+	$current_time = current_time('timestamp');
+
+	foreach ($lpv_data_array as $lpv_data) {
+	    $viewed_time = $lpv_data['timestamp'];
+	    if ($viewed_time >= strtotime('-1 hour', $current_time)) {
+	        $lpv_data_period_counts['hour']++;
+	    }
+	    if ($viewed_time >= strtotime('-1 day', $current_time)) {
+	        $lpv_data_period_counts['day']++;
+	    }
+	    if ($viewed_time >= strtotime('-1 week', $current_time)) {
+	        $lpv_data_period_counts['week']++;
+	    }
+	    if ($viewed_time >= strtotime('-1 month', $current_time)) {
+	        $lpv_data_period_counts['month']++;
+	    }
 	}
 
 	// Get all of the user's current membership level IDs.
@@ -120,8 +129,8 @@ function pmprolpv_get_restriction_js() {
 
 	// If the user has remaining views, track the view in the cookie and alert the number of views remaining.
 	if ( $views_remaining > 0 ) {
-		$lpv_data_string .= ';' . $post_id . ',' . current_time( 'timestamp' );
-		setcookie( 'pmprolpv', $lpv_data_string, current_time( 'timestamp' ) + 60 * 60 * 24 * 30, COOKIEPATH, COOKIE_DOMAIN );
+		$lpv_data_string .= ';' . $post_id . ',' . $current_time;
+		setcookie( 'pmprolpv', $lpv_data_string, $current_time + 60 * 60 * 24 * 30, COOKIEPATH, COOKIE_DOMAIN );
 
 		// Decrement views_remaining now that we added a view.
 		$views_remaining--;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-limit-post-views/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-post-views/pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Empty Checks: Added checks to ensure that explode is only called on non-empty strings for both `$lpv_data_string` and `$lpv_data`.
2. Data Type Casting: Explicitly cast `$post_id` and `$timestamp` to integers for type safety.
3. Readability: Changed the `switch` waterfall into simple `if` statements for better readability and consistency.
4. Performance: Store the result of `current_time( 'timestamp' )` to avoid repeated function calls.

Resolves `PHP Warning:  Undefined array key 1 in /plugins/pmpro-limit-post-views/includes/restriction.php on line 72` that is filling our WP_DEBUG logs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?




