### PR TITLE
Improve compatibility with Add Ons that restrict access to posts

### DIFF
--- a/includes/restriction.php
+++ b/includes/restriction.php
@@ -53,10 +53,16 @@ function pmprolpv_get_restriction_js() {
 		wp_send_json_success( 'return;' );
 	}
 
+	// Check if the user has access to the post.
+	// If they don't even when we are filtering to true, then another plugin is blocking access. Let them continue handling it.
+	if ( ! pmpro_has_membership_access( $post_id ) ) {
+		wp_send_json_success( '' );
+	}
+
 	// Unhook the LPV has_access filter to see if the user truly has access to this post.
 	remove_filter( 'pmpro_has_membership_access_filter', 'pmprolpv_has_membership_access_filter', 10, 2 );
 
-	// Check if the user has access to the post.
+	// Check if the user has access to the post. If they do, then they don't need to use a LPV view to access this content.
 	if ( pmpro_has_membership_access( $post_id ) ) {
 		wp_send_json_success( 'return;' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-limit-post-views/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-post-views/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
For example, with the Approvals Add On, sites may not want users to get free LPV views until their membership is approved. This PR makes it possible for Approvals to block access to content and show their no access message without it counting against the user's LPV count.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
