### PR TITLE
Fix array_merge() error

### DIFF
--- a/pmpro-limit-post-views.php
+++ b/pmpro-limit-post-views.php
@@ -40,8 +40,9 @@ function pmprolpv_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . get_admin_url( null, 'admin.php?page=pmpro-limitpostviews' ) . '">' . __( 'Settings', 'pmpro-limit-post-views' ) . '</a>',
 		);
+		return array_merge( $new_links, $links );
 	}
-	return array_merge( $new_links, $links );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'pmprolpv_plugin_action_links' );
 


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-limit-post-views/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-post-views/pulls) for the same update/change?

### Changelog entry

> Fixes an error that occurred when null was passed to array_merge.
