### PR TITLE
Skip levels that do not have a view limit set when calculating max remaining views

### DIFF
--- a/includes/restriction.php
+++ b/includes/restriction.php
@@ -121,6 +121,11 @@ function pmprolpv_get_restriction_js() {
 		// Get the limits for this level.
 		$level_limit = pmprolpv_get_level_limit( $level_id );
 
+		// If a view limit is not present, skip this level.
+		if ( empty( $level_limit['views'] ) || empty( $level_limit['period'] ) ) {
+    			continue;
+		}
+
 		// Update $views_remaining based on this level's data.
 		if ( $level_limit['views'] - $lpv_data_period_counts[ $level_limit['period'] ] > $views_remaining ) {
 			$views_remaining = $level_limit['views'] - $lpv_data_period_counts[ $level_limit['period'] ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/pmpro-limit-post-views/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-limit-post-views/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
A fatal error would be triggered when retrieving the restriction JS if members of a level with no view limits set ( _views per_ setting field left blank) tried accessing restricted content. Members of the level would get unlimited access to all member-only content.

Skipping levels that do not have a view limit set when calculating the maximum remaining views for a user.

Resolves #67 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
